### PR TITLE
Update 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 61ae5ec1db233aba947a48e1ce54c6ff66afd0e1c87195d6bce64c73a5ae658c
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     - pip check | rg -F "requires poetry, which is not installed."
     # Ensure pip check does not output anything else. (This includes
     # "No broken requirements found." -- a signal to update the recipe ;)
-    - "! pip check | grep -Fv "requires poetry, which is not installed."  # [not win]
+    - "! pip check | grep -Fv 'requires poetry, which is not installed.'"  # [not win]
   requires:
     - pip
     - ripgrep

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,11 +18,11 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core
+    - poetry-core >=1.3.0,<2.0.0
     - setuptools
     - wheel
   run:
-    - python >=3.7,<4.0
+    - python
     - poetry-core >=1.3.0,<2.0.0
   # poetry is actually a run dependency. But since that creates a dependency
   # cycle, we add it only as a run_constrained for now (until fixed upstream).
@@ -38,6 +38,7 @@ requirements:
 test:
   imports:
     #   - poetry_plugin_export
+    - run_test.py
   commands:
     - pip check
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
@@ -53,9 +54,12 @@ test:
 about:
   home: https://pypi.org/project/poetry-plugin-export/
   summary: Poetry plugin to export the dependencies to various formats
+  description: This package is a plugin that allows the export of locked packages to various formats.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   dev_url: https://github.com/python-poetry/poetry-plugin-export
+  doc_url: https://github.com/python-poetry/poetry-plugin-export
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core 1.5.1
+    - poetry-core
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,11 @@ requirements:
 
   # Skip tests partially due to dependency cycle (see above):
   # File/version check instead of import test; ignored poetry dep in pip check
-  test:
-    # imports:
+test:
+  imports:
     #   - poetry_plugin_export
   commands:
+    - pip check
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
     - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
     # Ensure pip check has non-empty output and recognizes the missing dep.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.7,<4.0
+    - python
     - pip
-    - poetry-core >=1.3.0,<2.0.0
+    - poetry-core
+    - setuptools
+    - wheel
   run:
     - python >=3.7,<4.0
     - poetry-core >=1.3.0,<2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   skip: true  # [py<37]
+  skip: true  # [unix]
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,15 +39,17 @@ test:
   imports:
   #   - poetry_plugin_export
   commands:
-    - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
-    - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
+    - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py  # [not win]
+    - if not exist %SP_DIR%/poetry_plugin_export/__init__.py exit 1  #[win]
+    - 'pip show poetry-plugin-export | rg -F "Version: {{ version }}"'
     # Ensure pip check has non-empty output and recognizes the missing dep.
-    - pip check | grep -F 'requires poetry, which is not installed.'
+    - pip check | rg -F "requires poetry, which is not installed."
     # Ensure pip check does not output anything else. (This includes
     # "No broken requirements found." -- a signal to update the recipe ;)
-    - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
+    - "! pip check | grep -Fv "requires poetry, which is not installed."  # [not win]
   requires:
     - pip
+    - ripgrep
 
 about:
   home: https://pypi.org/project/poetry-plugin-export/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     - pip check | grep -F 'requires poetry, which is not installed.'
     # Ensure pip check does not output anything else. (This includes
     # "No broken requirements found." -- a signal to update the recipe ;)
-    # - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
+    - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core 1.5.2
+    - poetry-core 1.5.1
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core >=1.3.0,<2.0.0
+    - poetry-core 1.5.2
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,19 +16,34 @@ build:
 
 requirements:
   host:
-    - pip
     - python >=3.7,<4.0
-    - poetry-core
+    - pip
+    - poetry-core >=1.3.0,<2.0.0
   run:
     - python >=3.7,<4.0
-    - poetry >=1.2.0b3,<2.0.0
-    - poetry-core >=1.1.0b3,<2.0.0
+    - poetry-core >=1.3.0,<2.0.0
+  # poetry is actually a run dependency. But since that creates a dependency
+  # cycle, we add it only as a run_constrained for now (until fixed upstream).
+  # (N.B.: This means this package is unusable if `conda install`ed on its own.)
+  # refs:
+  #  - https://github.com/python-poetry/poetry/pull/5980
+  #  - https://github.com/conda-forge/poetry-feedstock/issues/70
+  run_constrained:
+    - poetry >=1.3.0,<2.0.0
 
-test:
-  imports:
-    - poetry_plugin_export
+  # Skip tests partially due to dependency cycle (see above):
+  # File/version check instead of import test; ignored poetry dep in pip check
+  test:
+    # imports:
+    #   - poetry_plugin_export
   commands:
-    - pip check
+    - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
+    - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
+    # Ensure pip check has non-empty output and recognizes the missing dep.
+    - pip check | grep -F 'requires poetry, which is not installed.'
+    # Ensure pip check does not output anything else. (This includes
+    # "No broken requirements found." -- a signal to update the recipe ;)
+    - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,9 @@ requirements:
   # Skip tests partially due to dependency cycle (see above):
   # File/version check instead of import test; ignored poetry dep in pip check
 test:
-  imports:
-    #   - poetry_plugin_export
-    - run_test.py
+  # imports:
+  #   - poetry_plugin_export
   commands:
-    - pip check
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
     - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
     # Ensure pip check has non-empty output and recognizes the missing dep.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,11 @@ requirements:
   # Skip tests partially due to dependency cycle (see above):
   # File/version check instead of import test; ignored poetry dep in pip check
 test:
-  # imports:
+  imports:
   #   - poetry_plugin_export
   commands:
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
-    - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
+    # - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
     # Ensure pip check has non-empty output and recognizes the missing dep.
     - pip check | grep -F 'requires poetry, which is not installed.'
     # Ensure pip check does not output anything else. (This includes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core
+    - poetry-core 1.5.1
     - setuptools
     - wheel
   run:
@@ -43,10 +43,10 @@ test:
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
     - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
     # Ensure pip check has non-empty output and recognizes the missing dep.
-    # - pip check | grep -F 'requires poetry, which is not installed.'
+    - pip check | grep -F 'requires poetry, which is not installed.'
     # Ensure pip check does not output anything else. (This includes
     # "No broken requirements found." -- a signal to update the recipe ;)
-    - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
+    # - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "poetry-plugin-export" %}
-{% set version = "1.0.6" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/poetry-plugin-export-{{ version }}.tar.gz
-  sha256: af870afceb38e583afa57bcfadfa5cd35ebd74e35aacadcb802bb3a073c13adb
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/poetry_plugin_export-{{ version }}.tar.gz
+  sha256: 61ae5ec1db233aba947a48e1ce54c6ff66afd0e1c87195d6bce64c73a5ae658c
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   skip: true  # [py<37]
-  skip: true  # [unix]
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,9 @@ test:
   #   - poetry_plugin_export
   commands:
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
-    # - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
+    - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
     # Ensure pip check has non-empty output and recognizes the missing dep.
-    - pip check | grep -F 'requires poetry, which is not installed.'
+    # - pip check | grep -F 'requires poetry, which is not installed.'
     # Ensure pip check does not output anything else. (This includes
     # "No broken requirements found." -- a signal to update the recipe ;)
     - "! pip check | grep -Fv 'requires poetry, which is not installed.'"


### PR DESCRIPTION
[Upstream](https://github.com/python-poetry/poetry-plugin-export)
[Changelog](https://github.com/python-poetry/poetry-plugin-export/blob/main/CHANGELOG.md)

### Actions
- Update version and sha256
- Remove noarch and add build skip for <37
- Dependency updates
- Linter fixes
- Needed to modify test section syntax to allow for windows builds (Thank you @ELundby45)